### PR TITLE
Farben

### DIFF
--- a/slotgrafik.py
+++ b/slotgrafik.py
@@ -128,7 +128,7 @@ class ZugFarbschema:
             (40000, 42999): 'tab:blue',
             (43000, 44999): 'tab:purple',
             (45000, 49999): 'tab:cyan',
-            (50000, 50199): 'tab:orange',
+            (50000, 50199): 'tab:olive',
             (50200, 87599): 'tab:cyan',
             (87600, 87999): 'tab:red',
             (88000, 95999): 'tab:cyan',

--- a/slotgrafik.py
+++ b/slotgrafik.py
@@ -135,26 +135,6 @@ class ZugFarbschema:
             (96000, 96999): 'tab:blue',
             (97000, 99999): 'tab:magenta'
         }
-"""
-        self.nach_nummer = {
-            (1, 400): 'tab:red',
-            (400, 1700): 'tab:orange',
-            (1700, 3400): 'tab:green',
-            (3400, 6000): 'tab:blue',
-            (6000, 8000): 'tab:blue',
-            (8000, 9000): 'tab:cyan',
-            (9200, 9800): 'tab:red',
-            (9850, 9899): 'tab:blue',
-            (10000, 11000): 'tab:pink',
-            (11000, 13000): 'tab:cyan',
-            (13600, 26000): 'tab:cyan',
-            (26000, 27000): 'tab:blue',
-            (27000, 40000): 'tab:pink',
-            (40000, 50000): 'tab:purple',
-            (50000, 60000): 'tab:olive',
-            (60000, 70000): 'tab:brown'
-        }
-"""
 
     def init_deutschland(self):
         self.nach_gattung = {

--- a/slotgrafik.py
+++ b/slotgrafik.py
@@ -113,6 +113,30 @@ class ZugFarbschema:
         }
 
         self.nach_nummer = {
+            (1, 4099): 'tab:red',
+            (4100, 8999): 'tab:orange',
+            (9000, 9849): 'tab:red',
+            (9850, 9899): 'tab:orange',
+            (9900, 10999): 'tab:red',
+            (11000, 26999): 'tab:orange',
+            (27000, 27999): 'tab:magenta',
+            (28000, 28999): 'tab:green',
+            (29000, 29999): 'tab:blue',
+            (30000, 35999): 'tab:green',
+            (36000, 36999): 'tab:blue',
+            (37000, 39999): 'tab:green',
+            (40000, 42999): 'tab:blue',
+            (43000, 44999): 'tab:purple',
+            (45000, 49999): 'tab:cyan',
+            (50000, 50199): 'tab:orange',
+            (50200, 87599): 'tab:cyan',
+            (87600, 87999): 'tab:red',
+            (88000, 95999): 'tab:cyan',
+            (96000, 96999): 'tab:blue',
+            (97000, 99999): 'tab:magenta'
+        }
+"""
+        self.nach_nummer = {
             (1, 400): 'tab:red',
             (400, 1700): 'tab:orange',
             (1700, 3400): 'tab:green',
@@ -130,6 +154,7 @@ class ZugFarbschema:
             (50000, 60000): 'tab:olive',
             (60000, 70000): 'tab:brown'
         }
+"""
 
     def init_deutschland(self):
         self.nach_gattung = {


### PR DESCRIPTION
Ich habe mir im jTrainGraph eine etwas umfangreichere Liste angelegt und dabei die Zugnummernblöcke der SBB als Stütze genommen für die Unterteilung. Ebenfalls die Farben sind an RCS angeglichen so gut als möglich/sinnvoll ist.