### PR TITLE
Fix gleiseditor checkboxes

### DIFF
--- a/stskit/widgets/gleisauswahl.py
+++ b/stskit/widgets/gleisauswahl.py
@@ -130,6 +130,7 @@ class GleisauswahlItem:
         if role == QtCore.Qt.EditRole:
             return False
         elif role == QtCore.Qt.CheckStateRole:
+            value = QtCore.Qt.CheckState(value)
             if column == 0:
                 self.setCheckState(value)
                 if len(self._children):


### PR DESCRIPTION
Warum auch immer ist value ein int und kein Qt.CheckedState, Vergleiche zwischen beiden schlagen deshalb immer fehl. Deswegen konnte man nur gleise abwählen aber nicht mehr auswählen und Sperrungen nicht mehr deaktivieren.