### PR TITLE
Fix fahrzeit manuell

### DIFF
--- a/stskit/model/liniengraph.py
+++ b/stskit/model/liniengraph.py
@@ -294,8 +294,13 @@ class LinienGraph(nx.Graph):
             fahrzeit = markierung_kfg.get('fahrzeit', 0)
             markierung = markierung_kfg.get('flags', '')
             if station1 in bahnhofgraph and station2 in bahnhofgraph:
+                if not self.has_edge(station1, station2):
+                    self.add_edge(station1, station2, fahrzeit_min=60*24, fahrzeit_max=0,
+                                          fahrten=0, fahrzeit_summe=0., fahrzeit_schnitt=0.)
                 self.edges[station1, station2]['markierung'] = markierung
                 self.edges[station1, station2]['fahrzeit_manuell'] = fahrzeit
+            else:
+                logger.warning(f"Streckenmarkierungszwischen {station1} und {station2} konnte nicht zugeordnet werden.")
 
 
     def export_konfiguration(self) -> Sequence[Dict[str, Union[str, int, float, bool]]]:

--- a/stskit/model/liniengraph.py
+++ b/stskit/model/liniengraph.py
@@ -300,7 +300,7 @@ class LinienGraph(nx.Graph):
                 self.edges[station1, station2]['markierung'] = markierung
                 self.edges[station1, station2]['fahrzeit_manuell'] = fahrzeit
             else:
-                logger.warning(f"Streckenmarkierungszwischen {station1} und {station2} konnte nicht zugeordnet werden.")
+                logger.warning(f"Streckenmarkierung zwischen {station1} und {station2} konnte nicht zugeordnet werden.")
 
 
     def export_konfiguration(self) -> Sequence[Dict[str, Union[str, int, float, bool]]]:

--- a/stskit/model/liniengraph.py
+++ b/stskit/model/liniengraph.py
@@ -320,6 +320,7 @@ class LinienGraph(nx.Graph):
             if d:
                 d['station1'] = str(e1)
                 d['station2'] = str(e2)
+                d['flags'] = m
                 result.append(d)
 
         return result


### PR DESCRIPTION
Folgende drei Bugs werden hiermit behoben:

1. import_konfiguration ignoriert Streckenmarkierungen die es nicht setzen konnte ohne dies zu loggen
2. Wenn beim ausführen von import_konfiguration die betroffene kante noch nicht existiert (da nicht über den Fahrplan gefunden), wird diese  Streckenmarkierungen ignoriert.
3. Wenn man eine Streckenmarkierung mit leeren Flags hat (nur fahrzeit_manuell), dann wird beim exportieren dieser flags nicht exportiert. Dies führt beim nächsten laden zu einem Schema-Fehler, da flags required ist. Alternativ könnte man auch flags optional machen, da hätte ich auch nichts gegen