### PR TITLE
allow non-integer numbers for fahrzeit

### DIFF
--- a/stskit/schema/config.schema3.json
+++ b/stskit/schema/config.schema3.json
@@ -151,7 +151,7 @@
                         "description": "Station: Anschlussstelle, Bahnhof oder Bahnhofteil, im Format 'Typ Name'"
                     },
                     "fahrzeit": {
-                        "type": "integer",
+                        "type": "number",
                         "minimum": 0,
                         "maximum": 60,
                         "description": "Durschnittliche Fahrzeit in Minuten. Bestimmt die Länge des Abschnitts im Bildfahrplan. Falls Null, wird die automatisch berechnete Fahrzeit verwendet."


### PR DESCRIPTION
strecken_zeitachse kann sowieso schon mit floats also wieso sollte man das verbieten